### PR TITLE
解决运行的时候注册中心协议问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+.DS_Store

--- a/yu-rpc-core/src/main/java/com/yupi/yurpc/config/RegistryConfig.java
+++ b/yu-rpc-core/src/main/java/com/yupi/yurpc/config/RegistryConfig.java
@@ -20,8 +20,9 @@ public class RegistryConfig {
 
     /**
      * 注册中心地址
+     * 注意：2379是etcd客户端通信端口，2380是集群内部通信端口
      */
-    private String address = "http://localhost:2380";
+    private String address = "http://localhost:2379";
 
     /**
      * 用户名


### PR DESCRIPTION
2379是etcd客户端通信端口，2380是集群内部通信端口
报错类似于如下:
22:57:47.264 [vert.x-eventloop-thread-0] DEBUG io.netty.handler.codec.http2.Http2ConnectionHandler -- [id: 0x243e5d9f, L:/127.0.0.1:65234 - R:localhost/127.0.0.1:2380] Sent GOAWAY: lastStreamId '2147483647', errorCode '1', debugData 'First received frame was not SETTINGS. Hex dump for first 5 bytes: 485454502f'. Forcing shutdown of the connection.